### PR TITLE
Improve Switch widget

### DIFF
--- a/cmd/demo/widgets.go
+++ b/cmd/demo/widgets.go
@@ -50,14 +50,14 @@ func makeSwitch() fyne.CanvasObject {
 		switchLabel1.SetText(textForBool(on))
 	})
 	switch1.On = true
-	switchLabel1.Text = textForBool(switch1.State())
+	switchLabel1.Text = textForBool(switch1.On)
 	switch1Box := container.NewHBox(switch1, switchLabel1)
 
 	switchLabel2 := widget.NewLabel("")
 	switch2 := kxwidget.NewSwitch(func(on bool) {
 		switchLabel2.SetText(textForBool(on))
 	})
-	switchLabel2.Text = textForBool(switch2.State())
+	switchLabel2.Text = textForBool(switch2.On)
 	switch2Box := container.NewHBox(switch2, switchLabel2)
 
 	switch3 := kxwidget.NewSwitch(nil)

--- a/widget/switch_test.go
+++ b/widget/switch_test.go
@@ -1,0 +1,47 @@
+package widget_test
+
+import (
+	"testing"
+
+	"fyne.io/fyne/v2/test"
+
+	"github.com/ErikKalkoken/fyne-kx/widget"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSwitch(t *testing.T) {
+	t.Run("can create initial switch", func(t *testing.T) {
+		w := widget.NewSwitch(nil)
+		window := test.NewWindow(w)
+		defer window.Close()
+		assert.False(t, w.On)
+	})
+	t.Run("should set state and ignore undefined callback", func(t *testing.T) {
+		w := widget.NewSwitch(nil)
+		window := test.NewWindow(w)
+		defer window.Close()
+		w.SetOn(true)
+		assert.True(t, w.On)
+	})
+	t.Run("should run callback when state changed", func(t *testing.T) {
+		var hasRun bool
+		w := widget.NewSwitch(func(on bool) {
+			hasRun = true
+		})
+		window := test.NewWindow(w)
+		defer window.Close()
+		w.SetOn(true)
+		assert.True(t, hasRun)
+	})
+	t.Run("should not run callback when state did not change", func(t *testing.T) {
+		var hasRun bool
+		w := widget.NewSwitch(func(on bool) {
+			hasRun = true
+		})
+		w.On = true
+		window := test.NewWindow(w)
+		defer window.Close()
+		w.SetOn(true)
+		assert.False(t, hasRun)
+	})
+}


### PR DESCRIPTION
- Adds `Switch.SetOn()` to replace `Switch.SetState()`
- Deprecates `Switch.SetState()` and `Switch.State()`
- Performance improvements
- Adds tests
- Refactoring
